### PR TITLE
[refactor] #79 aop를 활용하여 영수증 리뷰 어뷰징 방지

### DIFF
--- a/src/main/java/com/example/Petbulance_BE/domain/review/DailyLimit.java
+++ b/src/main/java/com/example/Petbulance_BE/domain/review/DailyLimit.java
@@ -1,0 +1,13 @@
+package com.example.Petbulance_BE.domain.review;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DailyLimit {
+    int maxCount() default 20;
+    int minInterval() default 3;
+}

--- a/src/main/java/com/example/Petbulance_BE/domain/review/DailyLimitAspect.java
+++ b/src/main/java/com/example/Petbulance_BE/domain/review/DailyLimitAspect.java
@@ -1,0 +1,65 @@
+package com.example.Petbulance_BE.domain.review;
+
+import com.example.Petbulance_BE.global.common.error.exception.CustomException;
+import com.example.Petbulance_BE.global.common.error.exception.ErrorCode;
+import com.example.Petbulance_BE.global.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DailyLimitAspect {
+
+    private final StringRedisTemplate redisTemplate;
+    private final UserUtil userUtil;
+
+    @Before("@annotation(dailyLimit)")
+    public void checkLimit(DailyLimit dailyLimit) {
+        String userId = userUtil.getCurrentUser().getId();
+        String today = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+
+        //하루동안 보낸 요청수, 마지막 요청 시간 키
+        String countKey = "daily_limit:"+userId+":"+today;
+        String timeKey = "last_access:"+userId;
+
+        //마지막 요청 시간
+        String lastTimeStr = redisTemplate.opsForValue().get(timeKey);
+
+        if(lastTimeStr != null) {
+            long lastTime = Long.parseLong(lastTimeStr);
+            long currentTime = System.currentTimeMillis();
+
+            if (currentTime - lastTime < (dailyLimit.minInterval() * 1000L)){
+                log.warn("너무 빠른 리뷰 요청 (매크로 의심)-UserId:{}",userId);
+                throw new CustomException(ErrorCode.TOO_FAST_REQUEST);
+            }
+        }
+
+        //ttl은 5초(3초 간격 검증이미로 충분)
+        redisTemplate.opsForValue().set(timeKey, String.valueOf(System.currentTimeMillis()), 5, TimeUnit.SECONDS);
+
+        Long count = redisTemplate.opsForValue().increment(countKey);
+
+        if(count !=null && count == 1){
+            redisTemplate.expire(countKey, 1, TimeUnit.DAYS);
+        }
+
+        if(count != null && count > dailyLimit.maxCount()){
+            throw new CustomException(ErrorCode.TOO_MANY_REQUEST);
+        }
+
+    }
+
+
+
+}

--- a/src/main/java/com/example/Petbulance_BE/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/Petbulance_BE/domain/review/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.example.Petbulance_BE.domain.review.service;
 import com.example.Petbulance_BE.domain.hospital.dto.UserReviewSearchDto;
 import com.example.Petbulance_BE.domain.hospital.entity.Hospital;
 import com.example.Petbulance_BE.domain.hospital.repository.HospitalJpaRepository;
+import com.example.Petbulance_BE.domain.review.DailyLimit;
 import com.example.Petbulance_BE.domain.review.dto.*;
 import com.example.Petbulance_BE.domain.review.dto.dao.MyReviewGetDao;
 import com.example.Petbulance_BE.domain.review.dto.req.FilterReqDto;
@@ -72,7 +73,7 @@ public class ReviewService {
         this.s3Service = s3Service;
         this.reviewImageJpaRepository = reviewImageJpaRepository;
     }
-
+    @DailyLimit
     public Mono<ReceiptResDto> receiptExtractProcess(MultipartFile image) {
 
         log.info("🚀 [{}] 요청 시작", Thread.currentThread().getName());

--- a/src/main/java/com/example/Petbulance_BE/global/common/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/Petbulance_BE/global/common/error/exception/ErrorCode.java
@@ -73,7 +73,9 @@ public enum ErrorCode {
     AI_RESPONSE_PARSING_ERROR(HttpStatus.BAD_REQUEST, "AI 응답을 분석하는 데 실패했습니다."),
     AI_DIAGNOSIS_FAIL(HttpStatus.BAD_REQUEST, "AI 진단에 실패했습니다."),
     BAD_IMAGE(HttpStatus.BAD_REQUEST, "이미지가 손상되었거나 동물이 아닙니다."),
-    TEXT_ERROR(HttpStatus.BAD_REQUEST, "텍스트의 내용이 적합하지 않습니다.");
+    TEXT_ERROR(HttpStatus.BAD_REQUEST, "텍스트의 내용이 적합하지 않습니다."),
+    TOO_FAST_REQUEST(HttpStatus.BAD_REQUEST, "리뷰 작성까지는 최소 3초의 간격이 필요합니다."),
+    TOO_MANY_REQUEST(HttpStatus.BAD_REQUEST, "일일 리뷰 작성 한도에 도달하였습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 📄 작업 내용 요약
스프링 aop를 활용하여 인증 로직과 검증 로직을 분리하고 과도한 리소스를 잡아먹는 매크로 방지 redis Atomic을 통한 동시성 문제 해결

## 📎 Issue 번호
<!-- closed #79 -